### PR TITLE
Add tests for ConfigParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,11 @@ config_parser.parse('config.yaml')
 data = config_parser.get_data()
 config_parser.validate_data()
 ```
+
+## 运行测试
+
+要运行测试用例，请执行以下命令：
+
+```bash
+python -m unittest discover tests
+```

--- a/test_files/config.json
+++ b/test_files/config.json
@@ -1,0 +1,25 @@
+{
+  "pile_groups": [
+    {
+      "type": "non-virtual",
+      "coordinates": [10.2, 5.6],
+      "properties": {
+        "diameter": 1.2,
+        "segments": [
+          {"depth": 5, "soil_type": "clay"},
+          {"depth": 10, "soil_type": "sand"}
+        ]
+      }
+    },
+    {
+      "type": "virtual",
+      "stiffness": [1000000, 1000000, 2000000, 0, 0, 0]
+    }
+  ],
+  "load_cases": [
+    {
+      "node": [0, 0, 0],
+      "forces": [0, 1000, 0, 0, 0, 0]
+    }
+  ]
+}

--- a/test_files/config.txt
+++ b/test_files/config.txt
@@ -1,0 +1,14 @@
+pile_groups:
+  - type: non-virtual 
+    coordinates: [10.2, 5.6]
+    properties:
+      diameter: 1.2
+      segments:
+        - {depth: 5, soil_type: clay}
+        - {depth: 10, soil_type: sand}
+  - type: virtual
+    stiffness: [1e6, 1e6, 2e6, 0, 0, 0]
+    
+load_cases:
+  - node: [0, 0, 0]
+    forces: [0, 1000, 0, 0, 0, 0]

--- a/test_files/config.yaml
+++ b/test_files/config.yaml
@@ -1,0 +1,14 @@
+pile_groups:
+  - type: non-virtual 
+    coordinates: [10.2, 5.6]
+    properties:
+      diameter: 1.2
+      segments:
+        - {depth: 5, soil_type: clay}
+        - {depth: 10, soil_type: sand}
+  - type: virtual
+    stiffness: [1e6, 1e6, 2e6, 0, 0, 0]
+    
+load_cases:
+  - node: [0, 0, 0]
+    forces: [0, 1000, 0, 0, 0, 0]

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,0 +1,28 @@
+import unittest
+from pypile.config_parser import ConfigParser
+
+class TestConfigParser(unittest.TestCase):
+
+    def test_yaml_parsing(self):
+        config_parser = ConfigParser()
+        config_parser.parse('tests/test_files/config.yaml')
+        data = config_parser.get_data()
+        print("YAML Parsed Data:", data)
+        self.assertIsNotNone(data)
+
+    def test_json_parsing(self):
+        config_parser = ConfigParser()
+        config_parser.parse('tests/test_files/config.json')
+        data = config_parser.get_data()
+        print("JSON Parsed Data:", data)
+        self.assertIsNotNone(data)
+
+    def test_text_parsing(self):
+        config_parser = ConfigParser()
+        config_parser.parse('tests/test_files/config.txt')
+        data = config_parser.get_data()
+        print("Text Parsed Data:", data)
+        self.assertIsNotNone(data)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add test cases for `ConfigParser` and sample configuration files.

* **tests/test_config_parser.py**
  - Add a new test file for `ConfigParser`.
  - Write three test cases for YAML, JSON, and text file parsing.
  - Print the parsed results in each test case.

* **README.md**
  - Add instructions on running the tests.

* **test_files/config.yaml**
  - Add a sample YAML configuration file for testing.

* **test_files/config.json**
  - Add a sample JSON configuration file for testing.

* **test_files/config.txt**
  - Add a sample text configuration file for testing.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ganansuan647/pypile/pull/2?shareId=c4585893-f8c8-4730-abf6-6b1a2a29b899).